### PR TITLE
Impoved Global ID handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ PRIVATE
     ${PROJECT_SOURCE_DIR}/src/Nodes/NodeManager.cpp
     ${PROJECT_SOURCE_DIR}/src/Nodes/Widgets.cpp
     ${PROJECT_SOURCE_DIR}/src/Nodes/Drawing.cpp
+    ${PROJECT_SOURCE_DIR}/src/Nodes/GlobalID.cpp
     
 )
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -417,24 +417,24 @@ std::shared_ptr<Node> Application::DrawNodeSpawnList()
     {
         if (ImGui::MenuItem("Button"))
         {
-            spawnedNode = nodeManager.SpawnNode<ButtonNode>(0);
+            spawnedNode = nodeManager.SpawnNode<ButtonNode>();
         }
         if (ImGui::MenuItem("Toggle"))
         {
-            spawnedNode = nodeManager.SpawnNode<ToggleNode>(0);
+            spawnedNode = nodeManager.SpawnNode<ToggleNode>();
         }
         if (ImGui::MenuItem("Timer"))
         {
-            spawnedNode =nodeManager.SpawnNode<TimerNode>(0);
+            spawnedNode =nodeManager.SpawnNode<TimerNode>();
         }
         ImGui::Separator();
         if (ImGui::MenuItem("String"))
         {
-            spawnedNode =nodeManager.SpawnNode<StringNode>(0);
+            spawnedNode =nodeManager.SpawnNode<StringNode>();
         }
         if (ImGui::MenuItem("Number"))
         {
-            spawnedNode =nodeManager.SpawnNode<NumberNode>(0);
+            spawnedNode =nodeManager.SpawnNode<NumberNode>();
         }
         ImGui::EndMenu();
     }
@@ -442,21 +442,21 @@ std::shared_ptr<Node> Application::DrawNodeSpawnList()
     if(ImGui::BeginMenu("Math")){
         if (ImGui::MenuItem("Concatenate"))
         {
-            spawnedNode =nodeManager.SpawnNode<ConcatNode>(0);
+            spawnedNode =nodeManager.SpawnNode<ConcatNode>();
         }
         ImGui::Separator();
 
         if (ImGui::MenuItem("Add"))
         {
-            spawnedNode =nodeManager.SpawnNode<AddNode>(0);
+            spawnedNode =nodeManager.SpawnNode<AddNode>();
         }
         if (ImGui::MenuItem("Subtract"))
         {
-            spawnedNode =nodeManager.SpawnNode<SubtractNode>(0);
+            spawnedNode =nodeManager.SpawnNode<SubtractNode>();
         }
         if (ImGui::MenuItem("Boolean Operator"))
         {
-            spawnedNode = nodeManager.SpawnNode<BooleanOperatorNode>(0);
+            spawnedNode = nodeManager.SpawnNode<BooleanOperatorNode>();
         }
             
         ImGui::EndMenu();
@@ -465,20 +465,20 @@ std::shared_ptr<Node> Application::DrawNodeSpawnList()
     if(ImGui::BeginMenu("Output")){
         if (ImGui::MenuItem("Print"))
         {
-            spawnedNode =nodeManager.SpawnNode<PrintNode>(0);
+            spawnedNode =nodeManager.SpawnNode<PrintNode>();
         }
         if(ImGui::MenuItem("Boolean Display"))
         {
-            spawnedNode  = nodeManager.SpawnNode<BooleanDisplayNode>(0);
+            spawnedNode  = nodeManager.SpawnNode<BooleanDisplayNode>();
         }
         ImGui::Separator();
         if (ImGui::MenuItem("TCP Client"))
         {
-            spawnedNode =nodeManager.SpawnNode<TCPClientNode>(0, tcpClient);
+            spawnedNode =nodeManager.SpawnNode<TCPClientNode>(tcpClient);
         }
         if (ImGui::MenuItem("TCP Server"))
         {
-            spawnedNode = nodeManager.SpawnNode<TCPServerNode>(0, tcpServer);
+            spawnedNode = nodeManager.SpawnNode<TCPServerNode>(tcpServer);
         }
         
         ImGui::EndMenu();

--- a/src/Nodes/AddNode.cpp
+++ b/src/Nodes/AddNode.cpp
@@ -3,7 +3,7 @@
 #include "misc/cpp/imgui_stdlib.h"
 #include <cmath>
 
-AddNode::AddNode(ax::NodeEditor::NodeId id) : ClonableNode<AddNode>(id)
+AddNode::AddNode() : ClonableNode<AddNode>()
 {
     AddOutputPin("Sum", Pin::PinType::Number);
     AddInputPin("A", Pin::PinType::Number);

--- a/src/Nodes/AddNode.h
+++ b/src/Nodes/AddNode.h
@@ -5,7 +5,7 @@
 class AddNode : public ClonableNode<AddNode>
 {
 public:
-    AddNode(ax::NodeEditor::NodeId id);
+    AddNode();
     void DrawImpl() final;
     void Update() final;
     std::string GetNodeTypeName() final;

--- a/src/Nodes/BooleanDisplayNode.cpp
+++ b/src/Nodes/BooleanDisplayNode.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 
 
-BooleanDisplayNode::BooleanDisplayNode(ax::NodeEditor::NodeId id) : ClonableNode<BooleanDisplayNode>(id)
+BooleanDisplayNode::BooleanDisplayNode() : ClonableNode<BooleanDisplayNode>()
 {
     AddInputPin("in", Pin::PinType::Boolean);
 }

--- a/src/Nodes/BooleanDisplayNode.h
+++ b/src/Nodes/BooleanDisplayNode.h
@@ -5,7 +5,7 @@
 class BooleanDisplayNode : public ClonableNode<BooleanDisplayNode>
 {
 public:
-    BooleanDisplayNode(ax::NodeEditor::NodeId id);
+    BooleanDisplayNode();
     void DrawImpl() final;
     std::string GetNodeTypeName() final;
 };

--- a/src/Nodes/BooleanOperatorNode.cpp
+++ b/src/Nodes/BooleanOperatorNode.cpp
@@ -3,7 +3,7 @@
 #include "misc/cpp/imgui_stdlib.h"
 #include <cmath>
 
-BooleanOperatorNode::BooleanOperatorNode(ax::NodeEditor::NodeId id) : ClonableNode<BooleanOperatorNode>(id)
+BooleanOperatorNode::BooleanOperatorNode() : ClonableNode<BooleanOperatorNode>()
 {
     AddOutputPin("Out", Pin::PinType::Boolean);
     AddInputPin("A", Pin::PinType::Boolean);

--- a/src/Nodes/BooleanOperatorNode.h
+++ b/src/Nodes/BooleanOperatorNode.h
@@ -9,7 +9,7 @@ enum OPERATOR
     AND, OR, NOT, XOR
 };
 public:
-    BooleanOperatorNode(ax::NodeEditor::NodeId id);
+    BooleanOperatorNode();
     void DrawImpl() final;
     void Update() final;
     void SpecialConstructFromJSON(const nlohmann::json& json) final;

--- a/src/Nodes/ButtonNode.cpp
+++ b/src/Nodes/ButtonNode.cpp
@@ -2,7 +2,7 @@
 #include "imgui_node_editor.h"
 #include "misc/cpp/imgui_stdlib.h"
 
-ButtonNode::ButtonNode(ax::NodeEditor::NodeId id) : ClonableNode<ButtonNode>(id)
+ButtonNode::ButtonNode() : ClonableNode<ButtonNode>()
 {
     AddOutputPin("", Pin::PinType::Boolean);
 }

--- a/src/Nodes/ButtonNode.h
+++ b/src/Nodes/ButtonNode.h
@@ -5,7 +5,7 @@
 class ButtonNode : public ClonableNode<ButtonNode>
 {
 public:
-    ButtonNode(ax::NodeEditor::NodeId id);
+    ButtonNode();
     void DrawImpl() final;
     std::string GetNodeTypeName() final;
 };

--- a/src/Nodes/ClonableNode.h
+++ b/src/Nodes/ClonableNode.h
@@ -5,7 +5,7 @@
 template <typename Derived>
 class ClonableNode : public Node {
 public:
-    ClonableNode(ax::NodeEditor::NodeId id) : Node(id){}
+    ClonableNode() : Node(){}
     std::shared_ptr<Node> Clone() const override {
         return std::make_shared<Derived>(static_cast<const Derived&>(*this));
     }

--- a/src/Nodes/ConcatNode.cpp
+++ b/src/Nodes/ConcatNode.cpp
@@ -3,7 +3,7 @@
 #include "misc/cpp/imgui_stdlib.h"
 #include <cmath>
 
-ConcatNode::ConcatNode(ax::NodeEditor::NodeId id) : ClonableNode<ConcatNode>(id)
+ConcatNode::ConcatNode() : ClonableNode<ConcatNode>()
 {
     AddOutputPin("Out", Pin::PinType::Any);
     AddInputPin("A", Pin::PinType::Any);

--- a/src/Nodes/ConcatNode.h
+++ b/src/Nodes/ConcatNode.h
@@ -5,7 +5,7 @@
 class ConcatNode : public ClonableNode<ConcatNode>
 {
 public:
-    ConcatNode(ax::NodeEditor::NodeId id);
+    ConcatNode();
     void DrawImpl() final;
     void Update() final;
     std::string GetNodeTypeName() final;

--- a/src/Nodes/GlobalID.cpp
+++ b/src/Nodes/GlobalID.cpp
@@ -1,0 +1,4 @@
+#include "Nodes/GlobalID.h"
+
+
+    uint64_t Nodes::globalID = 0;

--- a/src/Nodes/GlobalID.h
+++ b/src/Nodes/GlobalID.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <stdint.h>
+
+class Nodes
+{
+    public:
+        static uint64_t globalID;
+};

--- a/src/Nodes/Link.h
+++ b/src/Nodes/Link.h
@@ -2,16 +2,18 @@
 
 #include "imgui_node_editor.h"
 #include "Serialization/ISerializable.h"
+#include "Nodes/GlobalID.h"
 
 class Link : public Serialization::ISerializable
 {
 public:
-    Link(ax::NodeEditor::LinkId id, ax::NodeEditor::PinId startPinId, ax::NodeEditor::PinId endPinId)
-    : ID(id)
+    Link(ax::NodeEditor::PinId startPinId, ax::NodeEditor::PinId endPinId)
+    : ID(++Nodes::globalID)
     , StartPinID(startPinId)
     , EndPinID(endPinId)
     , Color(255, 255, 255)
     {}
+
 public:
     nlohmann::json Serialize() final 
     {

--- a/src/Nodes/Node.cpp
+++ b/src/Nodes/Node.cpp
@@ -1,15 +1,13 @@
 #include "Nodes/Node.h"
 #include "Nodes/NodeManager.h"
 
-Node::Node(ax::NodeEditor::NodeId nodeID)
-: id(nodeID)
-{
-    ++NodeManager::globalId;
-    if((uint64_t)id.AsPointer() == 0){id = NodeManager::globalId;}
+Node::Node()
+: id(++Nodes::globalID)
+{  
 }
 
 Node::Node(const Node& copy)
-: id(++NodeManager::globalId)
+: id(++Nodes::globalID)
 {
     for(auto& pin : copy.inputPins)
     {
@@ -70,13 +68,16 @@ nlohmann::json Node::Serialize()
     return json;
 }
 
-void Node::ConstructFromJSON(const nlohmann::json& json)
+void Node::ConstructFromJSON(const nlohmann::json& json, std::unordered_map<uint64_t, uint64_t>& idMap)
 {
     inputPins.clear();
     outputPins.clear();
     for (auto& [key, val] : json["pins"].items())
     {
-        std::shared_ptr<Pin> pin = std::make_shared<Pin>(val);
+        std::shared_ptr<Pin> pin = std::make_shared<Pin>(val, idMap);
+
+        //Map here
+
         if(pin->pinKind == ax::NodeEditor::PinKind::Input)
         {
             inputPins.emplace_back(pin);

--- a/src/Nodes/Node.cpp
+++ b/src/Nodes/Node.cpp
@@ -76,8 +76,6 @@ void Node::ConstructFromJSON(const nlohmann::json& json, std::unordered_map<uint
     {
         std::shared_ptr<Pin> pin = std::make_shared<Pin>(val, idMap);
 
-        //Map here
-
         if(pin->pinKind == ax::NodeEditor::PinKind::Input)
         {
             inputPins.emplace_back(pin);

--- a/src/Nodes/Node.h
+++ b/src/Nodes/Node.h
@@ -10,7 +10,7 @@
 class Node : public Serialization::ISerializable
 {
 public:
-    Node(ax::NodeEditor::NodeId id = 0);
+    Node();
     Node(const Node& copy);
     virtual ~Node() = default;
 public:
@@ -19,7 +19,7 @@ public:
     virtual void Update(){} 
     ImVec2 GetPosition() const { return ax::NodeEditor::GetNodePosition(id); }
     nlohmann::json Serialize();
-    void ConstructFromJSON(const nlohmann::json& json);
+    void ConstructFromJSON(const nlohmann::json& json, std::unordered_map<uint64_t, uint64_t>& idMap);
     const std::vector<std::shared_ptr<Pin>>& GetInputPins()  const { return inputPins;}
     const std::vector<std::shared_ptr<Pin>>& GetOutputPins() const { return outputPins;}
     void Draw(); 
@@ -29,7 +29,7 @@ public:
     void RemoveOutputPin();
 protected:
     virtual void SpecialSerialze(nlohmann::json&) {}
-    virtual void SpecialConstructFromJSON(const nlohmann::json&){}    
+    virtual void SpecialConstructFromJSON(const nlohmann::json&){}
     virtual void DrawImpl(){} 
     void DrawPins();
 public:

--- a/src/Nodes/NodeManager.cpp
+++ b/src/Nodes/NodeManager.cpp
@@ -20,7 +20,6 @@
 #include "Nodes/BooleanOperatorNode.h"
 #include "Nodes/BooleanDisplayNode.h"
 
-int NodeManager::globalId = 100;
 using json = nlohmann::json;
 
 NodeManager::NodeManager(std::shared_ptr<TCPServer> tcpServer, std::shared_ptr<TCPClient> tcpClient) 
@@ -93,83 +92,86 @@ void NodeManager::SpawnNodesFromFile()
 {
     std::ifstream ifs(queuedImportFilename);
 
+    // original, new
+    std::unordered_map<uint64_t, uint64_t> idMap;
+
     if(ifs.is_open())
     {
         json json = json::parse(ifs);
         
             for (auto& [key, val] : json["nodes"].items())
-                {
-                    std::string nodeType = val["type"];
-                    std::shared_ptr<Node> spawnedNode;
-                    
-                    ax::NodeEditor::NodeId id = (uint64_t)val["id"];
-                    if (nodeType == "ButtonNode")
-                    {
-                        spawnedNode =  SpawnNode<ButtonNode>(id);
-                    }
-                    if(nodeType == "BooleanOperatorNode")
-                    {
-                        spawnedNode = SpawnNode<BooleanOperatorNode>(id);
-                    }
-                    if(nodeType == "BooleanDisplayNode")
-                    {
-                        spawnedNode = SpawnNode<BooleanDisplayNode>(id);
-                    }
-                    if (nodeType == "TimerNode")
-                    {
-                        spawnedNode = SpawnNode<TimerNode>(id);
-                    }
-                    if (nodeType == "StringNode")
-                    {
-                        spawnedNode = SpawnNode<StringNode>(id);
-                    }
-                    if (nodeType == "NumberNode")
-                    {
-                        spawnedNode = SpawnNode<NumberNode>(id);
-                    }
-                    if (nodeType == "ConcatNode")
-                    {
-                        spawnedNode = SpawnNode<ConcatNode>(id);
-                    }
-                    if (nodeType == "AddNode")
-                    {
-                        spawnedNode = SpawnNode<AddNode>(id);
-                    }
-                    if (nodeType == "SubtractNode")
-                    {
-                        spawnedNode = SpawnNode<SubtractNode>(id);
-                    }
-                    if (nodeType == "PrintNode")
-                    {
-                        spawnedNode = SpawnNode<PrintNode>(id);
-                    }
-                    if (nodeType == "TCPClientNode")
-                    {
-                        spawnedNode = SpawnNode<TCPClientNode>(id, tcpClient);
-                    }
-                    if (nodeType == "TCPServerNode")
-                    {
-                        spawnedNode = SpawnNode<TCPServerNode>(id, tcpServer);
-                    }
-                    if(nodeType == "ToggleNode")
-                    {
-                        spawnedNode = SpawnNode<ToggleNode>(id);
-                    }
+            {
+                std::string nodeType = val["type"];
+                std::shared_ptr<Node> spawnedNode;
                 
-                    spawnedNode->ConstructFromJSON(val);
-                    float posX = val["pos_x"];
-                    float posY = val["pos_y"];
-                    ax::NodeEditor::SetNodePosition(id, {posX,posY});
-                }
-                for (auto& [key, val] : json["links"].items())
-                {
-                    NodeManager::globalId++;
-                    ax::NodeEditor::LinkId id = (uint64_t)val["id"];
-                    ax::NodeEditor::PinId startId = (uint64_t)val["startPinId"];
-                    ax::NodeEditor::PinId endId = (uint64_t)val["endPinId"];
+                ax::NodeEditor::NodeId id = (uint64_t)val["id"];
                 
-                    links.emplace_back(Link{id, startId, endId});
+                if (nodeType == "ButtonNode")
+                {
+                    spawnedNode =  SpawnNode<ButtonNode>();
                 }
+                if(nodeType == "BooleanOperatorNode")
+                {
+                    spawnedNode = SpawnNode<BooleanOperatorNode>();
+                }
+                if(nodeType == "BooleanDisplayNode")
+                {
+                    spawnedNode = SpawnNode<BooleanDisplayNode>();
+                }
+                if (nodeType == "TimerNode")
+                {
+                    spawnedNode = SpawnNode<TimerNode>();
+                }
+                if (nodeType == "StringNode")
+                {
+                    spawnedNode = SpawnNode<StringNode>();
+                }
+                if (nodeType == "NumberNode")
+                {
+                    spawnedNode = SpawnNode<NumberNode>();
+                }
+                if (nodeType == "ConcatNode")
+                {
+                    spawnedNode = SpawnNode<ConcatNode>();
+                }
+                if (nodeType == "AddNode")
+                {
+                    spawnedNode = SpawnNode<AddNode>();
+                }
+                if (nodeType == "SubtractNode")
+                {
+                    spawnedNode = SpawnNode<SubtractNode>();
+                }
+                if (nodeType == "PrintNode")
+                {
+                    spawnedNode = SpawnNode<PrintNode>();
+                }
+                if (nodeType == "TCPClientNode")
+                {
+                    spawnedNode = SpawnNode<TCPClientNode>(tcpClient);
+                }
+                if (nodeType == "TCPServerNode")
+                {
+                    spawnedNode = SpawnNode<TCPServerNode>(tcpServer);
+                }
+                if(nodeType == "ToggleNode")
+                {
+                    spawnedNode = SpawnNode<ToggleNode>();
+                }
+            
+                spawnedNode->ConstructFromJSON(val, idMap);
+                float posX = val["pos_x"];
+                float posY = val["pos_y"];
+                
+                ax::NodeEditor::SetNodePosition(spawnedNode->id, {posX,posY});
+            }
+            for (auto& [key, val] : json["links"].items())
+            {
+                ax::NodeEditor::PinId startId = idMap[(uint64_t)val["startPinId"]];
+                ax::NodeEditor::PinId endId = idMap[(uint64_t)val["endPinId"]];
+            
+                links.emplace_back(Link{startId, endId});
+            }
 
         ifs.close();
     }
@@ -243,14 +245,12 @@ void NodeManager::Update()
 
     for (auto& linkInfo : links)
     {
-        
         std::shared_ptr<Pin> inputPin = GetPinFromId(linkInfo.StartPinID);
         std::shared_ptr<Pin> outputPin = GetPinFromId(linkInfo.EndPinID);
         inputPin->isConnected = true;
         outputPin->isConnected = true;
         
         inputPin->value = outputPin->value;
-
         ax::NodeEditor::Link(linkInfo.ID, linkInfo.StartPinID, linkInfo.EndPinID, inputPin->GetColorFromType(), 2.0f);
     }
     // Handle creation action, returns true if editor want to create new object (node or link)
@@ -280,7 +280,7 @@ void NodeManager::Update()
                 if (ax::NodeEditor::AcceptNewItem())
                 {
                     // Since we accepted new link, lets add one to our list of links.
-                    links.push_back({ ax::NodeEditor::LinkId(++NodeManager::globalId), inputPinId, outputPinId});
+                    links.push_back({inputPinId, outputPinId});
                     
                     // Draw new link.
                     ax::NodeEditor::Link(links.back().ID, links.back().StartPinID, links.back().EndPinID,inputPin->GetColorFromType(), 2.0f);

--- a/src/Nodes/NodeManager.cpp
+++ b/src/Nodes/NodeManager.cpp
@@ -92,7 +92,6 @@ void NodeManager::SpawnNodesFromFile()
 {
     std::ifstream ifs(queuedImportFilename);
 
-    // original, new
     std::unordered_map<uint64_t, uint64_t> idMap;
 
     if(ifs.is_open())

--- a/src/Nodes/NodeManager.h
+++ b/src/Nodes/NodeManager.h
@@ -9,14 +9,12 @@
 #include "Serialization/ISerializable.h"
 #include <TCP/Client/TCPClient.h>
 #include <TCP/Server/TCPServer.h>
-
+#include "Nodes/GlobalID.h"
 
 class TCPClient;
 
 class NodeManager : public Serialization::ISerializable
 {
-public:
-    static int globalId;
 public:
     NodeManager(std::shared_ptr<TCPServer> tcpServer, std::shared_ptr<TCPClient> tcpClient);
 public:

--- a/src/Nodes/NumberNode.cpp
+++ b/src/Nodes/NumberNode.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 
 
-NumberNode::NumberNode(ax::NodeEditor::NodeId id) : ClonableNode<NumberNode>(id)
+NumberNode::NumberNode() : ClonableNode<NumberNode>()
 {
     AddOutputPin("Out", Pin::PinType::Number);
     AddInputPin("X", Pin::PinType::Number);

--- a/src/Nodes/NumberNode.h
+++ b/src/Nodes/NumberNode.h
@@ -4,7 +4,7 @@
 class NumberNode : public ClonableNode<NumberNode>
 {
 public:
-    NumberNode(ax::NodeEditor::NodeId id);
+    NumberNode();
     void DrawImpl() final;
     void Update() final;
     void SpecialConstructFromJSON(const nlohmann::json& json) final;

--- a/src/Nodes/Pin.cpp
+++ b/src/Nodes/Pin.cpp
@@ -8,7 +8,7 @@
 using json = nlohmann::json;
 
 Pin::Pin(const std::string& name, ax::NodeEditor::PinKind pinKind, PinType pinType)
-: id(++NodeManager::globalId)
+: id(++Nodes::globalID)
 , pinKind(pinKind)
 , pinType(pinType)
 , value(false)
@@ -17,22 +17,22 @@ Pin::Pin(const std::string& name, ax::NodeEditor::PinKind pinKind, PinType pinTy
     value = 0.0f;
 }
 
-Pin::Pin(json json)
-: id(0)
+Pin::Pin(json json, std::unordered_map<uint64_t, uint64_t>& idMap)
+: id(++Nodes::globalID)
 , pinKind(ax::NodeEditor::PinKind::Input)
 , pinType(PinType::Any)
 , value(false)
 , name("")
 {
-    ++NodeManager::globalId;
-    id = (uint64_t)json["id"];
+    
+    idMap[(uint64_t)json["id"]] = (uint64_t)id;
     pinKind = json["flow"] == 0 ? ax::NodeEditor::PinKind::Input : ax::NodeEditor::PinKind::Output;
     pinType = json["type"];
     name = json["name"];
 }
 
 Pin::Pin(Pin& copy)
-: id(++NodeManager::globalId)
+: id(++Nodes::globalID)
 , pinKind(copy.pinKind)
 , pinType(copy.pinType)
 , value(copy.value)

--- a/src/Nodes/Pin.h
+++ b/src/Nodes/Pin.h
@@ -19,7 +19,7 @@ public:
 
     Pin(const std::string& name, ax::NodeEditor::PinKind pinKind, PinType pinType);
     Pin(Pin& pin);
-    Pin(nlohmann::json json);
+    Pin(nlohmann::json json, std::unordered_map<uint64_t, uint64_t>& idMap);
     void Draw();
     std::string PinOutputToString();
     std::string GetName(){return name;}

--- a/src/Nodes/PrintNode.cpp
+++ b/src/Nodes/PrintNode.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 
 
-PrintNode::PrintNode(ax::NodeEditor::NodeId id) : ClonableNode<PrintNode>(id)
+PrintNode::PrintNode() : ClonableNode<PrintNode>()
 {
     AddInputPin("Trigger", Pin::PinType::Boolean);
     AddInputPin("String", Pin::PinType::Any);

--- a/src/Nodes/PrintNode.h
+++ b/src/Nodes/PrintNode.h
@@ -4,7 +4,7 @@
 class PrintNode : public ClonableNode<PrintNode>
 {
 public:
-    PrintNode(ax::NodeEditor::NodeId id);
+    PrintNode();
     void DrawImpl() final;
     void Update() final;
     void Print();

--- a/src/Nodes/StringNode.cpp
+++ b/src/Nodes/StringNode.cpp
@@ -3,7 +3,7 @@
 #include "misc/cpp/imgui_stdlib.h"
 
 
-StringNode::StringNode(ax::NodeEditor::NodeId id) : ClonableNode<StringNode>(id)
+StringNode::StringNode() : ClonableNode<StringNode>()
 {
     AddOutputPin("String", Pin::PinType::Any);
 }

--- a/src/Nodes/StringNode.h
+++ b/src/Nodes/StringNode.h
@@ -4,7 +4,7 @@
 class StringNode : public ClonableNode<StringNode>
 {
 public:
-    StringNode(ax::NodeEditor::NodeId id);
+    StringNode();
     void DrawImpl() final;
     void Update() final;
     void SpecialConstructFromJSON(const nlohmann::json& json) final;

--- a/src/Nodes/SubtractNode.cpp
+++ b/src/Nodes/SubtractNode.cpp
@@ -3,7 +3,7 @@
 #include "misc/cpp/imgui_stdlib.h"
 #include <cmath>
 
-SubtractNode::SubtractNode(ax::NodeEditor::NodeId id) : ClonableNode<SubtractNode>(id)
+SubtractNode::SubtractNode() : ClonableNode<SubtractNode>()
 {
     AddOutputPin("Diff", Pin::PinType::Number);
     AddInputPin("A", Pin::PinType::Number);

--- a/src/Nodes/SubtractNode.h
+++ b/src/Nodes/SubtractNode.h
@@ -4,7 +4,7 @@
 class SubtractNode : public ClonableNode<SubtractNode>
 {
 public:
-    SubtractNode(ax::NodeEditor::NodeId id);
+    SubtractNode();
     void DrawImpl() final;
     void Update() final;
     std::string GetNodeTypeName() final;

--- a/src/Nodes/TCPClientNode.cpp
+++ b/src/Nodes/TCPClientNode.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 
 
-TCPClientNode::TCPClientNode(ax::NodeEditor::NodeId id, std::shared_ptr<TCPClient> tcpClient) : ClonableNode<TCPClientNode>(id)
+TCPClientNode::TCPClientNode(std::shared_ptr<TCPClient> tcpClient) : ClonableNode<TCPClientNode>()
 , tcpClient(tcpClient)
 {
     AddInputPin("Send", Pin::PinType::Boolean);

--- a/src/Nodes/TCPClientNode.h
+++ b/src/Nodes/TCPClientNode.h
@@ -5,7 +5,7 @@
 class TCPClientNode : public ClonableNode<TCPClientNode>
 {
 public:
-    TCPClientNode(ax::NodeEditor::NodeId id, std::shared_ptr<TCPClient> tcpClient);
+    TCPClientNode(std::shared_ptr<TCPClient> tcpClient);
     void DrawImpl() final;
     void Update() final;
     void Send();

--- a/src/Nodes/TCPServerNode.cpp
+++ b/src/Nodes/TCPServerNode.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 
 
-TCPServerNode::TCPServerNode(ax::NodeEditor::NodeId id, std::shared_ptr<TCPServer> tcpServer) : ClonableNode<TCPServerNode>(id)
+TCPServerNode::TCPServerNode(std::shared_ptr<TCPServer> tcpServer) : ClonableNode<TCPServerNode>()
 , tcpServer(tcpServer)
 {
     AddInputPin("Send", Pin::PinType::Boolean);

--- a/src/Nodes/TCPServerNode.h
+++ b/src/Nodes/TCPServerNode.h
@@ -6,7 +6,7 @@
 class TCPServerNode : public ClonableNode<TCPServerNode>
 {
 public:
-    TCPServerNode(ax::NodeEditor::NodeId id, std::shared_ptr<TCPServer> tcpServer);
+    TCPServerNode(std::shared_ptr<TCPServer> tcpServer);
     void DrawImpl() final;
     void Update() final;
     void Send();

--- a/src/Nodes/TimerNode.cpp
+++ b/src/Nodes/TimerNode.cpp
@@ -3,7 +3,7 @@
 #include "misc/cpp/imgui_stdlib.h"
 
 
-TimerNode::TimerNode(ax::NodeEditor::NodeId id) : ClonableNode<TimerNode>(id)
+TimerNode::TimerNode() : ClonableNode<TimerNode>()
 {
     AddOutputPin("Trigger", Pin::PinType::Boolean);
     lastTriggerTime = std::chrono::high_resolution_clock::now();

--- a/src/Nodes/TimerNode.h
+++ b/src/Nodes/TimerNode.h
@@ -5,7 +5,7 @@
 class TimerNode : public ClonableNode<TimerNode>
 {
 public:
-    TimerNode(ax::NodeEditor::NodeId id);
+    TimerNode();
     void DrawImpl() final;
     void Update() final;
     void SpecialConstructFromJSON(const nlohmann::json& json) final;

--- a/src/Nodes/ToggleNode.cpp
+++ b/src/Nodes/ToggleNode.cpp
@@ -3,7 +3,7 @@
 #include "misc/cpp/imgui_stdlib.h"
 
 
-ToggleNode::ToggleNode(ax::NodeEditor::NodeId id) : ClonableNode<ToggleNode>(id)
+ToggleNode::ToggleNode() : ClonableNode<ToggleNode>()
 {
     AddOutputPin("", Pin::PinType::Boolean);
 }

--- a/src/Nodes/ToggleNode.h
+++ b/src/Nodes/ToggleNode.h
@@ -4,7 +4,7 @@
 class ToggleNode : public ClonableNode<ToggleNode>
 {
 public:
-    ToggleNode(ax::NodeEditor::NodeId id);
+    ToggleNode();
     void DrawImpl() final;
     void Update() final;
     void SpecialConstructFromJSON(const nlohmann::json& json) final;


### PR DESCRIPTION
There was some issues with ID conflicts (especially when duplicating or loading large numbers of complex nodes). This is the first in likely many commits to address this issue.

Generally philosophy moving forward is to disallow spawning nodes/pins/links with a specified ID. Instead ID's will always be generated for each spawn, and linkage will happen via translation map to convert old ID's to new.