### PR TITLE
Node/Link/Pin IDs as pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,6 @@ PRIVATE
     ${PROJECT_SOURCE_DIR}/src/Nodes/NodeManager.cpp
     ${PROJECT_SOURCE_DIR}/src/Nodes/Widgets.cpp
     ${PROJECT_SOURCE_DIR}/src/Nodes/Drawing.cpp
-    ${PROJECT_SOURCE_DIR}/src/Nodes/GlobalID.cpp
-    
 )
 
 file(COPY

--- a/src/Nodes/GlobalID.cpp
+++ b/src/Nodes/GlobalID.cpp
@@ -1,4 +1,0 @@
-#include "Nodes/GlobalID.h"
-
-
-    uint64_t Nodes::globalID = 0;

--- a/src/Nodes/GlobalID.h
+++ b/src/Nodes/GlobalID.h
@@ -1,8 +1,0 @@
-#pragma once
-#include <stdint.h>
-
-class Nodes
-{
-    public:
-        static uint64_t globalID;
-};

--- a/src/Nodes/Link.h
+++ b/src/Nodes/Link.h
@@ -3,16 +3,18 @@
 #include "imgui_node_editor.h"
 #include "Serialization/ISerializable.h"
 #include "Nodes/GlobalID.h"
+#include <iostream>
 
 class Link : public Serialization::ISerializable
 {
 public:
     Link(ax::NodeEditor::PinId startPinId, ax::NodeEditor::PinId endPinId)
-    : ID(++Nodes::globalID)
+    : ID(reinterpret_cast<uintptr_t>(this))
     , StartPinID(startPinId)
     , EndPinID(endPinId)
     , Color(255, 255, 255)
-    {}
+    {
+    }
 
 public:
     nlohmann::json Serialize() final 

--- a/src/Nodes/Link.h
+++ b/src/Nodes/Link.h
@@ -2,7 +2,6 @@
 
 #include "imgui_node_editor.h"
 #include "Serialization/ISerializable.h"
-#include "Nodes/GlobalID.h"
 #include <iostream>
 
 class Link : public Serialization::ISerializable

--- a/src/Nodes/Node.cpp
+++ b/src/Nodes/Node.cpp
@@ -2,12 +2,12 @@
 #include "Nodes/NodeManager.h"
 
 Node::Node()
-: id(++Nodes::globalID)
-{  
+: id(reinterpret_cast<uint64_t>(this))
+{
 }
 
 Node::Node(const Node& copy)
-: id(++Nodes::globalID)
+: id(reinterpret_cast<uint64_t>(this))
 {
     for(auto& pin : copy.inputPins)
     {

--- a/src/Nodes/NodeManager.cpp
+++ b/src/Nodes/NodeManager.cpp
@@ -45,9 +45,9 @@ nlohmann::json NodeManager::Serialize()
         json["nodes"] += node->Serialize();
     }
     
-    for(Link link : links)
+    for(auto& link : links)
     {
-        json["links"] += link.Serialize();
+        json["links"] += link->Serialize();
     }
     
     return json;
@@ -169,7 +169,7 @@ void NodeManager::SpawnNodesFromFile()
                 ax::NodeEditor::PinId startId = idMap[(uint64_t)val["startPinId"]];
                 ax::NodeEditor::PinId endId = idMap[(uint64_t)val["endPinId"]];
             
-                links.emplace_back(Link{startId, endId});
+                links.emplace_back(std::make_unique<Link>(startId, endId));
             }
 
         ifs.close();
@@ -181,7 +181,7 @@ void NodeManager::DeleteAllNodes()
 
     for(auto& link : links)
     {
-        ax::NodeEditor::DeleteLink(link.ID);
+        ax::NodeEditor::DeleteLink(link->ID);
     }
 
     links.clear();
@@ -244,13 +244,13 @@ void NodeManager::Update()
 
     for (auto& linkInfo : links)
     {
-        std::shared_ptr<Pin> inputPin = GetPinFromId(linkInfo.StartPinID);
-        std::shared_ptr<Pin> outputPin = GetPinFromId(linkInfo.EndPinID);
+        std::shared_ptr<Pin> inputPin = GetPinFromId(linkInfo->StartPinID);
+        std::shared_ptr<Pin> outputPin = GetPinFromId(linkInfo->EndPinID);
         inputPin->isConnected = true;
         outputPin->isConnected = true;
         
         inputPin->value = outputPin->value;
-        ax::NodeEditor::Link(linkInfo.ID, linkInfo.StartPinID, linkInfo.EndPinID, inputPin->GetColorFromType(), 2.0f);
+        ax::NodeEditor::Link(linkInfo->ID, linkInfo->StartPinID, linkInfo->EndPinID, inputPin->GetColorFromType(), 2.0f);
     }
     // Handle creation action, returns true if editor want to create new object (node or link)
     if (ax::NodeEditor::BeginCreate(ImColor(255, 255, 255), 2.0f))
@@ -279,10 +279,10 @@ void NodeManager::Update()
                 if (ax::NodeEditor::AcceptNewItem())
                 {
                     // Since we accepted new link, lets add one to our list of links.
-                    links.push_back({inputPinId, outputPinId});
+                    links.emplace_back(std::make_unique<Link>(inputPinId, outputPinId));
                     
                     // Draw new link.
-                    ax::NodeEditor::Link(links.back().ID, links.back().StartPinID, links.back().EndPinID,inputPin->GetColorFromType(), 2.0f);
+                    ax::NodeEditor::Link(links.back()->ID, links.back()->StartPinID, links.back()->EndPinID,inputPin->GetColorFromType(), 2.0f);
                 }
             }
             else
@@ -385,10 +385,10 @@ void NodeManager::ProcessQueuedDeletedNodes()
             {
                 for (auto& link : links)
                 {
-                    if (link.ID == deletedLinkId)
+                    if (link->ID == deletedLinkId)
                     {
-                        std::shared_ptr<Pin> inputPin = GetPinFromId(link.EndPinID);
-                        std::shared_ptr<Pin> outputPin = GetPinFromId(link.StartPinID);
+                        std::shared_ptr<Pin> inputPin = GetPinFromId(link->EndPinID);
+                        std::shared_ptr<Pin> outputPin = GetPinFromId(link->StartPinID);
 
                         if(inputPin)
                         {

--- a/src/Nodes/NodeManager.cpp
+++ b/src/Nodes/NodeManager.cpp
@@ -244,8 +244,8 @@ void NodeManager::Update()
 
     for (auto& linkInfo : links)
     {
-        std::shared_ptr<Pin> inputPin = GetPinFromId(linkInfo->StartPinID);
-        std::shared_ptr<Pin> outputPin = GetPinFromId(linkInfo->EndPinID);
+        Pin* inputPin = GetPinFromId(linkInfo->StartPinID);
+        Pin* outputPin = GetPinFromId(linkInfo->EndPinID);
         inputPin->isConnected = true;
         outputPin->isConnected = true;
         
@@ -259,8 +259,8 @@ void NodeManager::Update()
         if (ax::NodeEditor::QueryNewLink(&outputPinId, &inputPinId))
         {
             bool accept = false;
-            std::shared_ptr<Pin> inputPin = GetPinFromId(inputPinId);
-            std::shared_ptr<Pin> outputPin = GetPinFromId(outputPinId);
+            Pin* inputPin = GetPinFromId(inputPinId);
+            Pin* outputPin = GetPinFromId(outputPinId);
 
             if(inputPin->pinKind == ax::NodeEditor::PinKind::Input  && outputPin->pinKind == ax::NodeEditor::PinKind::Output)
             {
@@ -312,26 +312,9 @@ void NodeManager::Update()
     ProcessQueuedDeletedNodes();   
 }
 
-std::shared_ptr<Pin> NodeManager::GetPinFromId(ax::NodeEditor::PinId pinId)
+Pin* NodeManager::GetPinFromId(ax::NodeEditor::PinId pinId)
 {
-    for (auto& node : nodes)
-    {
-        for(std::shared_ptr<Pin> pin : node->GetOutputPins())
-        {
-            if(pin->id == pinId)
-            {
-                return pin;
-            }
-        }
-        for(std::shared_ptr<Pin> pin : node->GetInputPins())
-        {
-            if(pin->id == pinId)
-            {
-                return pin;
-            }
-        }
-    }
-    return nullptr;
+    return reinterpret_cast<Pin*>((uintptr_t)pinId);
 }
 
 void NodeManager::SelectAll()
@@ -387,8 +370,8 @@ void NodeManager::ProcessQueuedDeletedNodes()
                 {
                     if (link->ID == deletedLinkId)
                     {
-                        std::shared_ptr<Pin> inputPin = GetPinFromId(link->EndPinID);
-                        std::shared_ptr<Pin> outputPin = GetPinFromId(link->StartPinID);
+                        Pin* inputPin = GetPinFromId(link->EndPinID);
+                        Pin* outputPin = GetPinFromId(link->StartPinID);
 
                         if(inputPin)
                         {

--- a/src/Nodes/NodeManager.h
+++ b/src/Nodes/NodeManager.h
@@ -44,7 +44,7 @@ public:
     ax::NodeEditor::EditorContext* GetEditorContext();
     std::vector<std::shared_ptr<Node>>& GetNodes() {return nodes;}
     void Update();
-    std::shared_ptr<Pin> GetPinFromId(ax::NodeEditor::PinId pinId);
+    Pin* GetPinFromId(ax::NodeEditor::PinId pinId);
     void SerializeToFile(const std::string& filename);
 private:
     void ProcessQueuedDeletedNodes();

--- a/src/Nodes/NodeManager.h
+++ b/src/Nodes/NodeManager.h
@@ -9,7 +9,6 @@
 #include "Serialization/ISerializable.h"
 #include <TCP/Client/TCPClient.h>
 #include <TCP/Server/TCPServer.h>
-#include "Nodes/GlobalID.h"
 
 class TCPClient;
 

--- a/src/Nodes/NodeManager.h
+++ b/src/Nodes/NodeManager.h
@@ -55,7 +55,7 @@ private:
     std::shared_ptr<TCPClient> tcpClient;
     ax::NodeEditor::EditorContext* nodeEditorContext = nullptr;
     std::vector<std::shared_ptr<Node>> nodes;
-    std::vector<Link> links; 
+    std::vector<std::unique_ptr<Link>> links; 
     bool deleteAll = false;
     bool recenter = false;
     int waitingForDeleteCounter = 0;

--- a/src/Nodes/Pin.cpp
+++ b/src/Nodes/Pin.cpp
@@ -8,7 +8,7 @@
 using json = nlohmann::json;
 
 Pin::Pin(const std::string& name, ax::NodeEditor::PinKind pinKind, PinType pinType)
-: id(++Nodes::globalID)
+: id(reinterpret_cast<uint64_t>(this))
 , pinKind(pinKind)
 , pinType(pinType)
 , value(false)
@@ -18,7 +18,7 @@ Pin::Pin(const std::string& name, ax::NodeEditor::PinKind pinKind, PinType pinTy
 }
 
 Pin::Pin(json json, std::unordered_map<uint64_t, uint64_t>& idMap)
-: id(++Nodes::globalID)
+: id(reinterpret_cast<uint64_t>(this))
 , pinKind(ax::NodeEditor::PinKind::Input)
 , pinType(PinType::Any)
 , value(false)
@@ -32,7 +32,7 @@ Pin::Pin(json json, std::unordered_map<uint64_t, uint64_t>& idMap)
 }
 
 Pin::Pin(Pin& copy)
-: id(++Nodes::globalID)
+: id(reinterpret_cast<uint64_t>(this))
 , pinKind(copy.pinKind)
 , pinType(copy.pinType)
 , value(copy.value)


### PR DESCRIPTION
Removing global ID's in favor of pointer of object as ID. This gives both the advantage of not having to manage ID creation any more and the advantage of faster object lookup. This PR includes one optimization using the new faster lookup, but there are likely more waiting in the code. Note this is only possible because of the changes to how we pull in nodes from JSON using the new mapping system.